### PR TITLE
Tests for method chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ghooks": "^1.0.0",
     "koa": "^2.0.0-alpha.3",
     "mocha": "^2.0.0",
+    "node-parallel": "^0.1.6",
     "nyc": "^5.0.0",
     "supertest": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koa-path-match",
   "description": "koa route middleware",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "license": "MIT",
   "repository": "koajs/path-match",


### PR DESCRIPTION
An invalid usage of the `route` function in one of my implementations made me to think that it was a bug in this middleware.

For that reason I took a look to the test and I didn't find a test case for the `method` chaining, believing that my implementation was right, I wrote a test case to detect the supposed bug here; when I wrote the test case it passed so obviously the problem was in my implementation, but I thought it's worthwhile to have those test cases too.

This PR carries those test cases.